### PR TITLE
Feature/refactor virtual stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,6 @@ END drop // Drop the counter from the stack
 "Sum of all numbers not divisible by 3 or 5: " print print_int
 ```
 
-Invoking execve Linux syscall
-
-```pascal
-// The execve command is constructed with the following strace output:
-// execve("/usr/bin/wget", ["wget", "example.com", "-O", "example.html"], 0x7ffffec61f68)
-envp array("wget","example.com","-O","example.html") '/usr/bin/wget' 59 syscall3
-```
-
 ## Documentation
 
 - [Keywords](./docs/keywords.md)

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ FizzBuzz which also counts the sum of the numbers not divisible by 3 or 5
 0 // The sum of numbers not divisible by 3 or 5
 1 WHILE 30 >= DO
     IF 15 % 0 == DO
-        "FizzBuzz  " print print_int
+        "FizzBuzz  " print dup print_int
     ELIF 3 % 0 == DO
-        "Fizz      " print print_int
+        "Fizz      " print dup print_int
     ELIF 5 % 0 == DO
-        "Buzz      " print print_int
+        "Buzz      " print dup print_int
     ELSE
         // Add current number to the sum of numbers not divisible by 3 or 5
         dup rot + swap

--- a/compiler/asm.py
+++ b/compiler/asm.py
@@ -1,6 +1,6 @@
 from typing import List, Literal
-from compiler.defs import OpType, Op, Program, STACK, Token, TokenType
-from compiler.utils import check_popped_value_type, compiler_error
+from compiler.defs import OpType, Op, Program, STACK, Token
+from compiler.utils import compiler_error
 
 def generate_asm(program: Program, asm_file: str) -> None:
     for op in program:
@@ -35,7 +35,6 @@ def generate_asm(program: Program, asm_file: str) -> None:
         f.close()
 
 def get_op_asm(op: Op, program: Program) -> str:
-    token: Token = op.token
     if op.type == OpType.BREAK:
         return get_break_asm(op, program)
     elif op.type == OpType.DO:
@@ -49,88 +48,88 @@ def get_op_asm(op: Op, program: Program) -> str:
     elif op.type == OpType.ENDIF:
         return get_endif_asm(op)
     elif op.type == OpType.IF:
-        return get_if_asm(op)
+        return get_if_asm()
     elif op.type == OpType.PUSH_ARRAY:
         return get_push_array_asm(op)
     elif op.type == OpType.PUSH_CSTR:
         return get_push_cstr_asm(op)
     elif op.type == OpType.PUSH_INT:
-        return get_push_int_asm(token)
+        return get_push_int_asm(op.token.value)
     elif op.type == OpType.PUSH_STR:
         return get_push_str_asm(op)
     elif op.type == OpType.WHILE:
         return get_while_asm(op)
     elif op.type == OpType.INTRINSIC:
-        intrinsic: str = token.value.upper()
+        intrinsic: str = op.token.value.upper()
         if intrinsic == "DIV":
-            return get_div_asm(op)
+            return get_div_asm()
         elif intrinsic == "DIVMOD":
-            return get_divmod_asm(op)
+            return get_divmod_asm()
         elif intrinsic == "DROP":
-            return get_drop_asm(op)
+            return get_drop_asm()
         elif intrinsic == "DUP":
-            return get_dup_asm(op)
+            return get_dup_asm()
         elif intrinsic == "DUP2":
-            return get_dup2_asm(op)
+            return get_dup2_asm()
         elif intrinsic == "ENVP":
             return get_envp_asm()
         elif intrinsic == "EXIT":
             return get_exit_asm()
         elif intrinsic == "EQ":
-            return get_eq_asm(op)
+            return get_eq_asm()
         elif intrinsic == "GE":
-            return get_ge_asm(op)
+            return get_ge_asm()
         elif intrinsic == "GET_NTH":
             return get_nth_asm(op)
         elif intrinsic == "GT":
-            return get_gt_asm(op)
+            return get_gt_asm()
         elif intrinsic == "INPUT":
             return get_input_asm(op)
         elif intrinsic == "LE":
-            return get_le_asm(op)
+            return get_le_asm()
         elif intrinsic == "LT":
-            return get_lt_asm(op)
+            return get_lt_asm()
         elif intrinsic == "MINUS":
-            return get_minus_asm(op)
+            return get_minus_asm()
         elif intrinsic == "MOD":
-            return get_mod_asm(op)
+            return get_mod_asm()
         elif intrinsic == "MUL":
-            return get_mul_asm(op)
+            return get_mul_asm()
         elif intrinsic == "NE":
-            return get_ne_asm(op)
+            return get_ne_asm()
         elif intrinsic == "OVER":
-            return get_over_asm(op)
+            return get_over_asm()
         elif intrinsic == "PLUS":
-            return get_plus_asm(op)
+            return get_plus_asm()
         elif intrinsic == "POW":
             return get_pow_asm(op)
         # TODO: Merge PRINT and PRINT_INT
         elif intrinsic == "PRINT":
-            return get_string_output_asm(op, intrinsic)
+            return get_string_output_asm(intrinsic)
         elif intrinsic == "PRINT_INT":
             return get_print_int_asm()
         elif intrinsic == "PUTS":
-            return get_string_output_asm(op, intrinsic)
+            return get_string_output_asm(intrinsic)
         elif intrinsic == "ROT":
-            return get_rot_asm(op)
+            return get_rot_asm()
         elif intrinsic == "SWAP":
-            return get_swap_asm(op)
+            return get_swap_asm()
         elif intrinsic == "SWAP2":
-            return get_swap2_asm(op)
+            return get_swap2_asm()
         elif intrinsic == "SYSCALL0":
-            return get_syscall_asm(op, param_count=0)
+            return get_syscall_asm(param_count=0)
         elif intrinsic == "SYSCALL1":
-            return get_syscall_asm(op, param_count=1)
+            return get_syscall_asm(param_count=1)
         elif intrinsic == "SYSCALL2":
-            return get_syscall_asm(op, param_count=2)
+            return get_syscall_asm(param_count=2)
         elif intrinsic == "SYSCALL3":
-            return get_syscall_asm(op, param_count=3)
+            return get_syscall_asm(param_count=3)
         elif intrinsic == "SYSCALL4":
-            return get_syscall_asm(op, param_count=4)
+            return get_syscall_asm(param_count=4)
         elif intrinsic == "SYSCALL5":
-            return get_syscall_asm(op, param_count=5)
+            return get_syscall_asm(param_count=5)
         elif intrinsic == "SYSCALL6":
-            return get_syscall_asm(op, param_count=6)
+            return get_syscall_asm(param_count=6)
         else:
             compiler_error(op, "NOT_IMPLEMENTED", f"Intrinsic {intrinsic} has not been implemented.")
     else:
@@ -390,8 +389,8 @@ def get_endif_asm(op: Op) -> str:
     return f'ENDIF{op.id}:\n'
 
 # IF is like DUP, it duplicates the first element in the stack
-def get_if_asm(op: Op) -> str:
-    return get_dup_asm(op)
+def get_if_asm() -> str:
+    return get_dup_asm()
 
 def get_push_array_asm(op: Op) -> str:
     op_asm: str  = f'  mov rsi, s_arr{op.id} ; Pointer to array\n'
@@ -403,8 +402,8 @@ def get_push_cstr_asm(op: Op) -> str:
     op_asm      +=  '  push rsi\n'
     return op_asm
 
-def get_push_int_asm(token: Token) -> str:
-    op_asm: str  = f'  mov rax, {token.value}\n'
+def get_push_int_asm(integer: str) -> str:
+    op_asm: str  = f'  mov rax, {integer}\n'
     op_asm      +=  '  push rax\n'
     return op_asm
 
@@ -421,12 +420,10 @@ def get_push_str_asm(op: Op) -> str:
 # Also like DUP it duplicates the first element in the stack.
 def get_while_asm(op: Op) -> str:
     op_asm: str  = f'WHILE{op.id}:\n'
-    op_asm      +=  '  pop rax\n'
-    op_asm      +=  '  push rax\n'
-    op_asm      +=  '  push rax\n'
+    op_asm      += get_dup_asm()
     return op_asm
 
-def get_div_asm(op: Op) -> str:
+def get_div_asm() -> str:
     op_asm: str  = '  xor edx, edx ; Do not use floating point arithmetic\n'
     op_asm      += '  pop rbx\n'
     op_asm      += '  pop rax\n'
@@ -434,7 +431,7 @@ def get_div_asm(op: Op) -> str:
     op_asm      += '  push rax ; Quotient\n'
     return op_asm
 
-def get_divmod_asm(op: Op) -> str:
+def get_divmod_asm() -> str:
     op_asm: str  = '  xor edx, edx ; Do not use floating point arithmetic\n'
     op_asm      += '  pop rbx\n'
     op_asm      += '  pop rax\n'
@@ -443,16 +440,16 @@ def get_divmod_asm(op: Op) -> str:
     op_asm      += '  push rax ; Quotient\n'
     return op_asm
 
-def get_drop_asm(op: Op) -> str:
-    return '  add rsp, 8\n'
+def get_drop_asm(count: int = 1) -> str:
+    return f'  add rsp, {8*count}\n'
 
-def get_dup_asm(op: Op) -> str:
+def get_dup_asm() -> str:
     op_asm: str  = '  pop rax\n'
     op_asm      += '  push rax\n'
     op_asm      += '  push rax\n'
     return op_asm
 
-def get_dup2_asm(op: Op) -> str:
+def get_dup2_asm() -> str:
     op_asm: str  = '  pop rbx\n'
     op_asm      += '  pop rax\n'
     op_asm      += '  push rax\n'
@@ -462,7 +459,7 @@ def get_dup2_asm(op: Op) -> str:
     return op_asm
 
 def get_envp_asm() -> str:
-    op_asm: str  = '  mov rax, [rbp+8]\n'
+    op_asm: str  = '  mov rax, [rbp+24]\n'
     op_asm      += '  push rax\n'
     return op_asm
 
@@ -505,7 +502,7 @@ def get_nth_asm(op: Op) -> str:
     STACK.append(nth_element)
     return op_asm
 
-def get_gt_asm(op: Op) -> str:
+def get_gt_asm() -> str:
     return get_comparison_asm("cmovg")
 
 # User input is essentially a CSTR but the length is also pushed to the stack for possible printing
@@ -530,7 +527,7 @@ def get_lt_asm() -> str:
 def get_minus_asm() -> str:
     return get_arithmetic_asm("sub")
 
-def get_mod_asm(op: Op) -> str:
+def get_mod_asm() -> str:
     op_asm: str  = '  xor edx, edx ; Do not use floating point arithmetic\n'
     op_asm      += '  pop rbx\n'
     op_asm      += '  pop rax\n'
@@ -538,17 +535,17 @@ def get_mod_asm(op: Op) -> str:
     op_asm      += '  push rdx ; Remainder\n'
     return op_asm
 
-def get_mul_asm(op: Op) -> str:
+def get_mul_asm() -> str:
     op_asm: str  = '  pop rax\n'
     op_asm      += '  pop rbx\n'
     op_asm      += '  mul rbx\n'
     op_asm      += '  push rax\n'
     return op_asm
 
-def get_ne_asm(op: Op) -> str:
+def get_ne_asm() -> str:
     return get_comparison_asm("cmovne")
 
-def get_over_asm(op: Op) -> str:
+def get_over_asm() -> str:
     op_asm: str  = '  pop rax\n'
     op_asm      += '  pop rbx\n'
     op_asm      += '  push rbx\n'
@@ -563,30 +560,29 @@ def get_plus_asm() -> str:
 # TODO: Make "POW" Macro in Torth when Macro's are implemented
 def get_pow_asm(op: Op) -> str:
     do_jump_destination: str = f'END{op.id}'
-    mock_int_token: Token = Token('1', TokenType.INT, op.token.location)
-    op_asm: str  = get_over_asm(op)
-    op_asm      += get_push_int_asm(mock_int_token)
-    op_asm      += get_rot_asm(op)
-    op_asm      += get_rot_asm(op)
-    op_asm      += get_swap_asm(op)
+    op_asm: str  = get_over_asm()
+    op_asm      += get_push_int_asm('1')
+    op_asm      += get_rot_asm()
+    op_asm      += get_rot_asm()
+    op_asm      += get_swap_asm()
     op_asm      += get_while_asm(op)
-    op_asm      += get_rot_asm(op)
-    op_asm      += get_over_asm(op)
-    op_asm      += get_gt_asm(op)
+    op_asm      += get_rot_asm()
+    op_asm      += get_over_asm()
+    op_asm      += get_gt_asm()
     op_asm      += generate_do_asm(do_jump_destination)
-    op_asm      += get_swap_asm(op)
-    op_asm      += get_swap2_asm(op)
-    op_asm      += get_dup_asm(op)
-    op_asm      += get_rot_asm(op)
-    op_asm      += get_mul_asm(op)
-    op_asm      += get_swap_asm(op)
-    op_asm      += get_swap2_asm(op)
-    op_asm      += get_push_int_asm(mock_int_token)
-    op_asm      += get_plus_asm(op)
+    op_asm      += get_swap_asm()
+    op_asm      += get_swap2_asm()
+    op_asm      += get_dup_asm()
+    op_asm      += get_rot_asm()
+    op_asm      += get_mul_asm()
+    op_asm      += get_swap_asm()
+    op_asm      += get_swap2_asm()
+    op_asm      += get_push_int_asm('1')
+    op_asm      += get_plus_asm()
     op_asm      += f'  jmp WHILE{op.id}\n'
     op_asm      += f'{do_jump_destination}:\n'
     for _ in range(3):
-        op_asm  += get_drop_asm(op)
+        op_asm  += get_drop_asm()
     return op_asm
 
 def get_print_int_asm() -> str:
@@ -594,7 +590,7 @@ def get_print_int_asm() -> str:
     op_asm      += '  call PrintInt\n'
     return op_asm
 
-def get_string_output_asm(op: Op, intrinsic: str) -> str:
+def get_string_output_asm(intrinsic: str) -> str:
     op_asm: str  = '  pop rsi    ; *buf\n'
     op_asm      += '  pop rdx    ; count\n'
 
@@ -606,7 +602,7 @@ def get_string_output_asm(op: Op, intrinsic: str) -> str:
     op_asm      += '  syscall\n'
     return op_asm
 
-def get_rot_asm(op: Op) -> str:
+def get_rot_asm() -> str:
     op_asm: str  = '  pop rax\n'
     op_asm      += '  pop rbx\n'
     op_asm      += '  pop rcx\n'
@@ -615,14 +611,14 @@ def get_rot_asm(op: Op) -> str:
     op_asm      += '  push rbx\n'
     return op_asm
 
-def get_swap_asm(op: Op) -> str:
+def get_swap_asm() -> str:
     op_asm: str  = '  pop rax\n'
     op_asm      += '  pop rbx\n'
     op_asm      += '  push rax\n'
     op_asm      += '  push rbx\n'
     return op_asm
 
-def get_swap2_asm(op: Op) -> str:
+def get_swap2_asm() -> str:
     op_asm: str  = '  pop rax\n'
     op_asm      += '  pop rbx\n'
     op_asm      += '  pop rcx\n'
@@ -633,7 +629,7 @@ def get_swap2_asm(op: Op) -> str:
     op_asm      += '  push rcx\n'
     return op_asm
 
-def get_syscall_asm(op: Op, param_count: int) -> str:
+def get_syscall_asm(param_count: int) -> str:
     op_asm: str  = "  pop rax ; syscall\n"
 
     # Pop arguments to syscall argument registers

--- a/compiler/asm.py
+++ b/compiler/asm.py
@@ -71,8 +71,6 @@ def get_op_asm(op: Op, program: Program) -> str:
             return get_dup_asm()
         elif intrinsic == "DUP2":
             return get_dup2_asm()
-        elif intrinsic == "ENVP":
-            return get_envp_asm()
         elif intrinsic == "EXIT":
             return get_exit_asm()
         elif intrinsic == "EQ":
@@ -456,11 +454,6 @@ def get_dup2_asm() -> str:
     op_asm      += '  push rbx\n'
     op_asm      += '  push rax\n'
     op_asm      += '  push rbx\n'
-    return op_asm
-
-def get_envp_asm() -> str:
-    op_asm: str  = '  mov rax, [rbp+24]\n'
-    op_asm      += '  push rax\n'
     return op_asm
 
 def get_exit_asm() -> str:

--- a/compiler/asm.py
+++ b/compiler/asm.py
@@ -330,12 +330,7 @@ def get_do_asm(op: Op, program: Program) -> str:
             or ( parent_op_type == OpType.ELIF and op_type in (OpType.ELIF, OpType.ELSE, OpType.ENDIF) ) \
             or ( parent_op_type == OpType.WHILE and op_type == OpType.END and while_count == 0):
             jump_destination: str = program[i].type.name + str(i)
-            op_asm: str = generate_do_asm(jump_destination)
-            try:
-                STACK.pop()
-                STACK.pop()
-            except IndexError:
-                compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
+            op_asm: str = generate_do_asm(op, jump_destination)
             break
 
         if parent_op_type == OpType.WHILE and op_type == OpType.END:
@@ -733,7 +728,7 @@ def get_pow_asm(op: Op) -> str:
     op_asm      += get_rot_asm(op)
     op_asm      += get_over_asm(op)
     op_asm      += get_gt_asm(op)
-    op_asm      += generate_do_asm(do_jump_destination)
+    op_asm      += generate_do_asm(op, do_jump_destination)
     op_asm      += get_swap_asm(op)
     op_asm      += get_swap2_asm(op)
     op_asm      += get_dup_asm(op)

--- a/compiler/asm.py
+++ b/compiler/asm.py
@@ -330,7 +330,7 @@ def get_do_asm(op: Op, program: Program) -> str:
             or ( parent_op_type == OpType.ELIF and op_type in (OpType.ELIF, OpType.ELSE, OpType.ENDIF) ) \
             or ( parent_op_type == OpType.WHILE and op_type == OpType.END and while_count == 0):
             jump_destination: str = program[i].type.name + str(i)
-            op_asm: str = generate_do_asm(op, jump_destination)
+            op_asm: str = generate_do_asm(jump_destination)
             break
 
         if parent_op_type == OpType.WHILE and op_type == OpType.END:
@@ -728,7 +728,7 @@ def get_pow_asm(op: Op) -> str:
     op_asm      += get_rot_asm(op)
     op_asm      += get_over_asm(op)
     op_asm      += get_gt_asm(op)
-    op_asm      += generate_do_asm(op, do_jump_destination)
+    op_asm      += generate_do_asm(do_jump_destination)
     op_asm      += get_swap_asm(op)
     op_asm      += get_swap2_asm(op)
     op_asm      += get_dup_asm(op)

--- a/compiler/asm.py
+++ b/compiler/asm.py
@@ -331,6 +331,11 @@ def get_do_asm(op: Op, program: Program) -> str:
             or ( parent_op_type == OpType.WHILE and op_type == OpType.END and while_count == 0):
             jump_destination: str = program[i].type.name + str(i)
             op_asm: str = generate_do_asm(jump_destination)
+            try:
+                STACK.pop()
+                STACK.pop()
+            except IndexError:
+                compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
             break
 
         if parent_op_type == OpType.WHILE and op_type == OpType.END:

--- a/compiler/asm.py
+++ b/compiler/asm.py
@@ -746,7 +746,6 @@ def get_pow_asm(op: Op) -> str:
     try:
         exponent: str   = STACK.pop()
         number: str     = STACK.pop()
-        STACK.pop()
     except IndexError:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
     check_popped_value_type(op, number, expected_type='INT')

--- a/compiler/compile.py
+++ b/compiler/compile.py
@@ -15,7 +15,7 @@ def compile_code(tokens: List[Token], input_file: str, output_file: str) -> None
     asm_file: str = input_file.replace('.torth', '.asm')
     program: Program = generate_program(tokens)
     # Uncomment when type type_check_program is implemented
-    #type_check_program(program)
+    type_check_program(program)
     initialize_asm(asm_file)
     generate_asm(program, asm_file)
     compile_asm(asm_file)

--- a/compiler/compile.py
+++ b/compiler/compile.py
@@ -3,7 +3,7 @@ import subprocess
 from typing import List
 from compiler.asm import generate_asm, initialize_asm
 from compiler.defs import Program, Token
-from compiler.program import generate_program
+from compiler.program import generate_program, type_check_program
 
 def compile_asm(asm_file: str) -> None:
     subprocess.run(['nasm', '-felf64', f'-o{asm_file.replace(".asm", ".o")}', asm_file])
@@ -14,6 +14,8 @@ def link_object_file(obj_file: str, output_file: str) -> None:
 def compile_code(tokens: List[Token], input_file: str, output_file: str) -> None:
     asm_file: str = input_file.replace('.torth', '.asm')
     program: Program = generate_program(tokens)
+    # Uncomment when type type_check_program is implemented
+    #type_check_program(program)
     initialize_asm(asm_file)
     generate_asm(program, asm_file)
     compile_asm(asm_file)

--- a/compiler/compile.py
+++ b/compiler/compile.py
@@ -14,7 +14,6 @@ def link_object_file(obj_file: str, output_file: str) -> None:
 def compile_code(tokens: List[Token], input_file: str, output_file: str) -> None:
     asm_file: str = input_file.replace('.torth', '.asm')
     program: Program = generate_program(tokens)
-    # Uncomment when type type_check_program is implemented
     type_check_program(program)
     initialize_asm(asm_file)
     generate_asm(program, asm_file)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -67,7 +67,7 @@ def type_check_program(program: Program) -> None:
         elif op.type == OpType.ENDIF:
             continue #return type_check_endif(op)
         elif op.type == OpType.IF:
-            continue #return type_check_if(op)
+            return type_check_if(op)
         elif op.type == OpType.PUSH_ARRAY:
             continue #return type_check_push_array(op)
         elif op.type == OpType.PUSH_CSTR:
@@ -165,9 +165,20 @@ def type_check_do(op: Op) -> str:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
 
 # ELIF is like DUP, it duplicates the first element in the stack
-def type_check_elif(op: Op) -> str:
+def type_check_elif(op: Op) -> None:
     try:
         top: str = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
+    STACK.append(top)
+    STACK.append(top)
+
+def type_check_if(op: Op) -> None:
+    get_dup_asm(op)
+
+def get_dup_asm(op: Op) -> str:
+    try:
+        top = STACK.pop()
     except IndexError:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
     STACK.append(top)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -274,7 +274,7 @@ def type_check_plus(op: Op) -> None:
 # TODO: Make "POW" Macro in Torth when Macro's are implemented
 def type_check_pow(op: Op) -> None:
     type_check_over(op)             # OVER
-    STACK.append(op.token.value)    # PUSH_INT
+    STACK.append('1')               # PUSH_INT
     type_check_rot(op)              # ROT
     type_check_rot(op)              # ROT
     type_check_swap(op)             # SWAP
@@ -290,9 +290,9 @@ def type_check_pow(op: Op) -> None:
     type_check_mul(op)              # MUL
     type_check_swap(op)             # SWAP
     type_check_swap2(op)            # SWAP2
-    STACK.append(op.token.value)    # PUSH_INT
+    STACK.append('1')               # PUSH_INT
     type_check_plus(op)             # PLUS
-    for _ in range(3):
+    for _ in range(2):
         type_check_drop(op)         # DROP
 
     try:

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -91,7 +91,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "GE":
                 type_check_ge(op)
             elif intrinsic == "GET_NTH":
-                type_check_nth(op)
+                continue  # Type checking is performed when generating assembly
             elif intrinsic == "GT":
                 type_check_gt(op)
             elif intrinsic == "INPUT":
@@ -114,9 +114,7 @@ def type_check_program(program: Program) -> None:
                 type_check_plus(op)
             elif intrinsic == "POW":
                 type_check_pow(op)
-            elif intrinsic == "PRINT":
-                type_check_string_output(op, intrinsic)
-            elif intrinsic == "PUTS":
+            elif intrinsic in {"PRINT", "PUTS"}:
                 type_check_string_output(op, intrinsic)
             elif intrinsic == "ROT":
                 type_check_rot(op)
@@ -216,26 +214,6 @@ def type_check_ge(op: Op) -> None:
     check_popped_value_type(op, b, expected_type='INT')
     STACK.append(a)
     STACK.append(str(int(a>=b)))
-
-# Copies Nth element from the stack to the top of the stack
-def type_check_nth(op: Op) -> None:
-    # The top element in the stack is the N
-    try:
-        n: int = int(STACK.pop()) - 1
-        if n < 0:
-            compiler_error(op, "STACK_INDEX_ERROR", "Stack index N cannot be <= 0.")
-    except IndexError:
-        compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
-    except ValueError:
-        compiler_error(op, "STACK_VALUE_ERROR", "First element in the stack is not a non-zero positive integer.")
-    try:
-        stack_index: int = len(STACK) - 1
-        nth_element: str = STACK[stack_index - n]
-    except IndexError:
-        compiler_error(op, "NOT_ENOUGH_ELEMENTS_IN_STACK", \
-                    f"Cannot get {n+1}. element from the stack: Stack only contains {len(STACK)} elements.")
-
-    STACK.append(nth_element)
 
 def type_check_gt(op: Op) -> None:
     a, b = pop_two_from_stack(op)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -1,6 +1,7 @@
 import subprocess
 from typing import List
-from compiler.defs import TokenType, Token, OpType, Program, Op, Intrinsic
+from compiler.defs import Intrinsic, Op, OpType, Program, STACK, TokenType, Token
+from compiler.utils import compiler_error
 
 def intrinsic_exists(token: str) -> bool:
     return bool(hasattr(Intrinsic, token))
@@ -46,3 +47,119 @@ def generate_program(tokens = List[Token]) -> Program:
 
 def run_code(exe_file: str) -> None:
     subprocess.run([f'./{exe_file}'])
+
+# Type check all operations which
+def type_check_program(program: Program) -> None:
+    global STACK
+    NOT_TYPED_TOKENS: List[Token] = [ 'BREAK', 'ELSE', 'END', 'ENDIF', 'EXIT', 'PRINT_INT' ]
+    for op in program:
+        token: Token = op.token
+        if token.value.upper() in NOT_TYPED_TOKENS:
+            continue
+        elif op.type == OpType.DO:
+            return type_check_do(op)
+        elif op.type == OpType.ELIF:
+            continue #return type_check_elif(op, program)
+        elif op.type == OpType.ELSE:
+            continue #return type_check_else(op, program)
+        elif op.type == OpType.END:
+            continue #return type_check_end(op, program)
+        elif op.type == OpType.ENDIF:
+            continue #return type_check_endif(op)
+        elif op.type == OpType.IF:
+            continue #return type_check_if(op)
+        elif op.type == OpType.PUSH_ARRAY:
+            continue #return type_check_push_array(op)
+        elif op.type == OpType.PUSH_CSTR:
+            continue #return type_check_push_cstr(op)
+        elif op.type == OpType.PUSH_INT:
+            continue #return type_check_push_int(token)
+        elif op.type == OpType.PUSH_STR:
+            continue #return type_check_push_str(op)
+        elif op.type == OpType.WHILE:
+            continue #return type_check_while(op)
+        elif op.type == OpType.INTRINSIC:
+            intrinsic: str = token.value.upper()
+            if intrinsic == "AND":
+                continue #return type_check_and(op)
+            elif intrinsic == "DIV":
+                continue #return type_check_div(op)
+            elif intrinsic == "DIVMOD":
+                continue #return type_check_divmod(op)
+            elif intrinsic == "DROP":
+                continue #return type_check_drop(op)
+            elif intrinsic == "DUP":
+                continue #return type_check_dup(op)
+            elif intrinsic == "DUP2":
+                continue #return type_check_dup2(op)
+            elif intrinsic == "ENVP":
+                continue #return type_check_envp()
+            elif intrinsic == "EXIT":
+                continue #return type_check_exit()
+            elif intrinsic == "EQ":
+                continue #return type_check_eq(op)
+            elif intrinsic == "GE":
+                continue #return type_check_ge(op)
+            elif intrinsic == "GET_NTH":
+                continue #return type_check_nth(op)
+            elif intrinsic == "GT":
+                continue #return type_check_gt(op)
+            elif intrinsic == "INPUT":
+                continue #return type_check_input(op)
+            elif intrinsic == "LE":
+                continue #return type_check_le(op)
+            elif intrinsic == "LT":
+                continue #return type_check_lt(op)
+            elif intrinsic == "MINUS":
+                continue #return type_check_minus(op)
+            elif intrinsic == "MOD":
+                continue #return type_check_mod(op)
+            elif intrinsic == "MUL":
+                continue #return type_check_mul(op)
+            elif intrinsic == "NE":
+                continue #return type_check_ne(op)
+            elif intrinsic == "OVER":
+                continue #return type_check_over(op)
+            elif intrinsic == "PLUS":
+                continue #return type_check_plus(op)
+            elif intrinsic == "POW":
+                continue #return type_check_pow(op)
+            # TODO: Merge PRINT and PRINT_INT
+            elif intrinsic == "PRINT":
+                continue #return type_check_string_output(op, intrinsic)
+            elif intrinsic == "PRINT_INT":
+                continue #return type_check_print_int()
+            elif intrinsic == "PUTS":
+                continue #return type_check_string_output(op, intrinsic)
+            elif intrinsic == "ROT":
+                continue #return type_check_rot(op)
+            elif intrinsic == "SWAP":
+                continue #return type_check_swap(op)
+            elif intrinsic == "SWAP2":
+                continue #return type_check_swap2(op)
+            elif intrinsic == "SYSCALL0":
+                continue #return type_check_syscall(op, param_count=0)
+            elif intrinsic == "SYSCALL1":
+                continue #return type_check_syscall(op, param_count=1)
+            elif intrinsic == "SYSCALL2":
+                continue #return type_check_syscall(op, param_count=2)
+            elif intrinsic == "SYSCALL3":
+                continue #return type_check_syscall(op, param_count=3)
+            elif intrinsic == "SYSCALL4":
+                continue #return type_check_syscall(op, param_count=4)
+            elif intrinsic == "SYSCALL5":
+                continue #return type_check_syscall(op, param_count=5)
+            elif intrinsic == "SYSCALL6":
+                continue #return type_check_syscall(op, param_count=6)
+            else:
+                compiler_error(op, "NOT_IMPLEMENTED", f"Type checking for {intrinsic} has not been implemented.")
+        else:
+            compiler_error(op, "NOT_IMPLEMENTED", f"Type checking for {op.type.name} has not been implemented.")
+    raise NotImplementedError("Type checking is not implemented yet.")
+
+def type_check_do(op: Op) -> str:
+    try:
+        STACK.pop()
+        STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -121,7 +121,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "ROT":
                 type_check_rot(op)
             elif intrinsic == "SWAP":
-                continue #return type_check_swap(op)
+                type_check_swap(op)
             elif intrinsic == "SWAP2":
                 continue #return type_check_swap2(op)
             elif intrinsic == "SYSCALL0":
@@ -312,3 +312,8 @@ def type_check_rot(op: Op) -> None:
     STACK.append(a)
     STACK.append(c)
     STACK.append(b)
+
+def type_check_swap(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    STACK.append(b)
+    STACK.append(a)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -107,7 +107,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "MUL":
                 type_check_mul(op)
             elif intrinsic == "NE":
-                continue #return type_check_ne(op)
+                type_check_ne(op)
             elif intrinsic == "OVER":
                 continue #return type_check_over(op)
             elif intrinsic == "PLUS":
@@ -274,3 +274,10 @@ def type_check_mod(op: Op) -> None:
 def type_check_mul(op: Op) -> None:
     a, b = pop_two_from_stack(op)
     STACK.append(str(int(a) * int(b)))
+
+def type_check_ne(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    check_popped_value_type(op, a, expected_type='INT')
+    check_popped_value_type(op, b, expected_type='INT')
+    STACK.append(a)
+    STACK.append(str(int(a!=b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -105,7 +105,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "MOD":
                 type_check_mod(op)
             elif intrinsic == "MUL":
-                continue #return type_check_mul(op)
+                type_check_mul(op)
             elif intrinsic == "NE":
                 continue #return type_check_ne(op)
             elif intrinsic == "OVER":
@@ -270,3 +270,7 @@ def type_check_minus(op: Op) -> None:
 def type_check_mod(op: Op) -> None:
     a, b = pop_two_from_stack(op)
     STACK.append(str(int(a) % int(b)))
+
+def type_check_mul(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    STACK.append(str(int(a) * int(b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -113,7 +113,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "PLUS":
                 type_check_plus(op)
             elif intrinsic == "POW":
-                continue #return type_check_pow(op)
+                type_check_pow(op)
             elif intrinsic == "PRINT":
                 type_check_string_output(op, intrinsic)
             elif intrinsic == "PUTS":
@@ -290,6 +290,41 @@ def type_check_over(op: Op) -> None:
 def type_check_plus(op: Op) -> None:
     a, b = pop_two_from_stack(op)
     STACK.append(str(int(a) + int(b)))
+
+# The sequence of operations is from examples/pow.torth
+# TODO: Make "POW" Macro in Torth when Macro's are implemented
+def type_check_pow(op: Op) -> None:
+    type_check_over(op)             # OVER
+    STACK.append(op.token.value)    # PUSH_INT
+    type_check_rot(op)              # ROT
+    type_check_rot(op)              # ROT
+    type_check_swap(op)             # SWAP
+    type_check_dup(op)              # WHILE
+    type_check_rot(op)              # ROT
+    type_check_over(op)             # OVER
+    type_check_gt(op)               # GT
+    type_check_do(op)               # DO
+    type_check_swap(op)             # SWAP
+    type_check_swap2(op)            # SWAP2
+    type_check_dup(op)              # DUP
+    type_check_rot(op)              # ROT
+    type_check_mul(op)              # MUL
+    type_check_swap(op)             # SWAP
+    type_check_swap2(op)            # SWAP2
+    STACK.append(op.token.value)    # PUSH_INT
+    type_check_plus(op)             # PLUS
+    for _ in range(3):
+        type_check_drop(op)         # DROP
+
+    try:
+        exponent: str   = STACK.pop()
+        number: str     = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
+
+    check_popped_value_type(op, number, expected_type='INT')
+    check_popped_value_type(op, exponent, expected_type='INT')
+    STACK.append(str(int(number)**int(exponent)))
 
 def type_check_string_output(op: Op, intrinsic: str) -> None:
     try:

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -101,7 +101,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "LT":
                 type_check_lt(op)
             elif intrinsic == "MINUS":
-                continue #return type_check_minus(op)
+                type_check_minus(op)
             elif intrinsic == "MOD":
                 continue #return type_check_mod(op)
             elif intrinsic == "MUL":
@@ -262,3 +262,7 @@ def type_check_lt(op: Op) -> None:
     check_popped_value_type(op, b, expected_type='INT')
     STACK.append(a)
     STACK.append(str(int(a<b)))
+
+def type_check_minus(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    STACK.append(str(int(a) + int(b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -79,7 +79,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "DIVMOD":
                 type_check_divmod(op)
             elif intrinsic == "DROP":
-                continue #return type_check_drop(op)
+                type_check_drop(op)
             elif intrinsic == "DUP":
                 continue #return type_check_dup(op)
             elif intrinsic == "DUP2":
@@ -152,7 +152,7 @@ def type_check_do(op: Op) -> None:
     except IndexError:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
 
-def type_check_push_str(op: Op) -> str:
+def type_check_push_str(op: Op) -> None:
     str_val: str = op.token.value[1:-1]  # Take quotes out of the string
     str_len: int = len(str_val) + 1      # Add newline
     STACK.append(f"{str_len}")
@@ -187,7 +187,13 @@ def type_check_divmod(op: Op) -> None:
     except ZeroDivisionError:
         compiler_error(op, "DIVISION_BY_ZERO", "Division by zero is not possible.")
 
-def type_check_dup(op: Op) -> str:
+def type_check_drop(op: Op) -> None:
+    try:
+        STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot drop value from empty stack.")
+
+def type_check_dup(op: Op) -> None:
     try:
         top = STACK.pop()
     except IndexError:

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -156,12 +156,12 @@ def type_check_do(op: Op) -> None:
 
 # ELIF is like DUP, it duplicates the first element in the stack
 def type_check_elif(op: Op) -> None:
-    get_dup_asm(op)
+    type_check_dup(op)
 
 def type_check_if(op: Op) -> None:
-    get_dup_asm(op)
+    type_check_dup(op)
 
-def get_dup_asm(op: Op) -> str:
+def type_check_dup(op: Op) -> str:
     try:
         top = STACK.pop()
     except IndexError:

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -95,7 +95,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "GT":
                 type_check_gt(op)
             elif intrinsic == "INPUT":
-                continue #return type_check_input(op)
+                type_check_input()
             elif intrinsic == "LE":
                 continue #return type_check_le(op)
             elif intrinsic == "LT":
@@ -244,3 +244,7 @@ def type_check_gt(op: Op) -> None:
     check_popped_value_type(op, b, expected_type='INT')
     STACK.append(a)
     STACK.append(str(int(a>b)))
+
+def type_check_input() -> None:
+    STACK.append(f"42") # User input length is not known beforehand
+    STACK.append(f"*buf buffer")

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -116,9 +116,9 @@ def type_check_program(program: Program) -> None:
                 continue #return type_check_pow(op)
             # TODO: Merge PRINT and PRINT_INT
             elif intrinsic == "PRINT":
-                continue #return type_check_string_output(op, intrinsic)
+                type_check_string_output(op, intrinsic)
             elif intrinsic == "PUTS":
-                continue #return type_check_string_output(op, intrinsic)
+                type_check_string_output(op, intrinsic)
             elif intrinsic == "ROT":
                 continue #return type_check_rot(op)
             elif intrinsic == "SWAP":
@@ -291,3 +291,14 @@ def type_check_over(op: Op) -> None:
 def type_check_plus(op: Op) -> None:
     a, b = pop_two_from_stack(op)
     STACK.append(str(int(a) + int(b)))
+
+def type_check_string_output(op: Op, intrinsic: str) -> str:
+    try:
+        buf    = STACK.pop()
+        count  = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", \
+            f"Not enough values in the stack for syscall 'write'.\n{intrinsic} operand requires two values, *buf and count.")
+
+    check_popped_value_type(op, buf, expected_type='*buf')
+    check_popped_value_type(op, count, expected_type='INT')

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -166,12 +166,7 @@ def type_check_do(op: Op) -> str:
 
 # ELIF is like DUP, it duplicates the first element in the stack
 def type_check_elif(op: Op) -> None:
-    try:
-        top: str = STACK.pop()
-    except IndexError:
-        compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
-    STACK.append(top)
-    STACK.append(top)
+    get_dup_asm(op)
 
 def type_check_if(op: Op) -> None:
     get_dup_asm(op)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -142,7 +142,6 @@ def type_check_program(program: Program) -> None:
                 compiler_error(op, "NOT_IMPLEMENTED", f"Type checking for {intrinsic} has not been implemented.")
         else:
             compiler_error(op, "NOT_IMPLEMENTED", f"Type checking for {op.type.name} has not been implemented.")
-    raise NotImplementedError("Type checking is not implemented yet.")
 
 def pop_two_from_stack(op: Op) -> Tuple[str, str]:
     try:
@@ -167,7 +166,7 @@ def type_check_div(op: Op) -> None:
     check_popped_value_type(op, b, expected_type='INT')
 
     try:
-        STACK.append(str(int(b) // int(a)))
+        STACK.append(str(int(a) // int(b)))
     except ZeroDivisionError:
         compiler_error(op, "DIVISION_BY_ZERO", "Division by zero is not possible.")
 
@@ -244,7 +243,7 @@ def type_check_lt(op: Op) -> None:
 
 def type_check_minus(op: Op) -> None:
     a, b = pop_two_from_stack(op)
-    STACK.append(str(int(a) + int(b)))
+    STACK.append(str(int(a) - int(b)))
 
 def type_check_mod(op: Op) -> None:
     a, b = pop_two_from_stack(op)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -59,7 +59,7 @@ def type_check_program(program: Program) -> None:
         elif op.type == OpType.DO:
             return type_check_do(op)
         elif op.type == OpType.ELIF:
-            continue #return type_check_elif(op, program)
+            return type_check_elif(op)
         elif op.type == OpType.ELSE:
             continue #return type_check_else(op, program)
         elif op.type == OpType.END:
@@ -163,3 +163,12 @@ def type_check_do(op: Op) -> str:
         STACK.pop()
     except IndexError:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
+
+# ELIF is like DUP, it duplicates the first element in the stack
+def type_check_elif(op: Op) -> str:
+    try:
+        top: str = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
+    STACK.append(top)
+    STACK.append(top)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -63,7 +63,7 @@ def type_check_program(program: Program) -> None:
         elif op.type == OpType.IF:
             return type_check_if(op)
         elif op.type == OpType.PUSH_ARRAY:
-            continue #return type_check_push_array(op)
+            return type_check_push_array(op)
         elif op.type == OpType.PUSH_CSTR:
             continue #return type_check_push_cstr(op)
         elif op.type == OpType.PUSH_INT:
@@ -168,3 +168,6 @@ def get_dup_asm(op: Op) -> str:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
     STACK.append(top)
     STACK.append(top)
+
+def type_check_push_array(op: Op) -> None:
+    STACK.append(f"*buf s_arr{op.id}")

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -109,7 +109,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "NE":
                 type_check_ne(op)
             elif intrinsic == "OVER":
-                continue #return type_check_over(op)
+                type_check_over(op)
             elif intrinsic == "PLUS":
                 continue #return type_check_plus(op)
             elif intrinsic == "POW":
@@ -281,3 +281,9 @@ def type_check_ne(op: Op) -> None:
     check_popped_value_type(op, b, expected_type='INT')
     STACK.append(a)
     STACK.append(str(int(a!=b)))
+
+def type_check_over(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    STACK.append(a)
+    STACK.append(b)
+    STACK.append(a)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -91,7 +91,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "GE":
                 type_check_ge(op)
             elif intrinsic == "GET_NTH":
-                continue #return type_check_nth(op)
+                type_check_nth(op)
             elif intrinsic == "GT":
                 continue #return type_check_gt(op)
             elif intrinsic == "INPUT":
@@ -217,3 +217,23 @@ def type_check_ge(op: Op) -> None:
     check_popped_value_type(op, b, expected_type='INT')
     STACK.append(a)
     STACK.append(str(int(a>=b)))
+
+# Copies Nth element from the stack to the top of the stack
+def type_check_nth(op: Op) -> None:
+    # The top element in the stack is the N
+    try:
+        n: int = int(STACK.pop()) - 1
+        if n < 0:
+            compiler_error(op, "STACK_INDEX_ERROR", "Stack index N cannot be <= 0.")
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
+    except ValueError:
+        compiler_error(op, "STACK_VALUE_ERROR", "First element in the stack is not a non-zero positive integer.")
+    try:
+        stack_index: int = len(STACK) - 1
+        nth_element: str = STACK[stack_index - n]
+    except IndexError:
+        compiler_error(op, "NOT_ENOUGH_ELEMENTS_IN_STACK", \
+                    f"Cannot get {n+1}. element from the stack: Stack only contains {len(STACK)} elements.")
+
+    STACK.append(nth_element)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -89,7 +89,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "EQ":
                 type_check_eq(op)
             elif intrinsic == "GE":
-                continue #return type_check_ge(op)
+                type_check_ge(op)
             elif intrinsic == "GET_NTH":
                 continue #return type_check_nth(op)
             elif intrinsic == "GT":
@@ -210,3 +210,10 @@ def type_check_eq(op: Op) -> None:
     check_popped_value_type(op, b, expected_type='INT')
     STACK.append(a)
     STACK.append(str(int(a==b)))
+
+def type_check_ge(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    check_popped_value_type(op, a, expected_type='INT')
+    check_popped_value_type(op, b, expected_type='INT')
+    STACK.append(a)
+    STACK.append(str(int(a>=b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -71,7 +71,7 @@ def type_check_program(program: Program) -> None:
         elif op.type == OpType.PUSH_STR:
             return type_check_push_str(op)
         elif op.type == OpType.WHILE:
-            continue #return type_check_while(op)
+            type_check_dup(op)
         elif op.type == OpType.INTRINSIC:
             intrinsic: str = token.value.upper()
             if intrinsic == "AND":

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -67,7 +67,7 @@ def type_check_program(program: Program) -> None:
         elif op.type == OpType.PUSH_CSTR:
             return type_check_push_cstr(op)
         elif op.type == OpType.PUSH_INT:
-            continue #return type_check_push_int(token)
+            STACK.append(op.token.value)
         elif op.type == OpType.PUSH_STR:
             continue #return type_check_push_str(op)
         elif op.type == OpType.WHILE:

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -77,7 +77,7 @@ def type_check_program(program: Program) -> None:
             if intrinsic == "DIV":
                 type_check_div(op)
             elif intrinsic == "DIVMOD":
-                continue #return type_check_divmod(op)
+                type_check_divmod(op)
             elif intrinsic == "DROP":
                 continue #return type_check_drop(op)
             elif intrinsic == "DUP":
@@ -152,21 +152,13 @@ def type_check_do(op: Op) -> None:
     except IndexError:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
 
-def type_check_dup(op: Op) -> str:
-    try:
-        top = STACK.pop()
-    except IndexError:
-        compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
-    STACK.append(top)
-    STACK.append(top)
-
 def type_check_push_str(op: Op) -> str:
     str_val: str = op.token.value[1:-1]  # Take quotes out of the string
     str_len: int = len(str_val) + 1      # Add newline
     STACK.append(f"{str_len}")
     STACK.append(f"*buf s{op.id}")
 
-def type_check_div(op: Op) -> str:
+def type_check_div(op: Op) -> None:
     try:
         a = STACK.pop()
         b = STACK.pop()
@@ -179,3 +171,26 @@ def type_check_div(op: Op) -> str:
         STACK.append(str(int(b) // int(a)))
     except ZeroDivisionError:
         compiler_error(op, "DIVISION_BY_ZERO", "Division by zero is not possible.")
+
+def type_check_divmod(op: Op) -> None:
+    try:
+        a = STACK.pop()
+        b = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
+
+    check_popped_value_type(op, a, expected_type='INT')
+    check_popped_value_type(op, b, expected_type='INT')
+    try:
+        STACK.append(str(int(a)% int(b)))
+        STACK.append(str(int(a)//int(b)))
+    except ZeroDivisionError:
+        compiler_error(op, "DIVISION_BY_ZERO", "Division by zero is not possible.")
+
+def type_check_dup(op: Op) -> str:
+    try:
+        top = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
+    STACK.append(top)
+    STACK.append(top)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -97,7 +97,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "INPUT":
                 type_check_input()
             elif intrinsic == "LE":
-                continue #return type_check_le(op)
+                type_check_le(op)
             elif intrinsic == "LT":
                 continue #return type_check_lt(op)
             elif intrinsic == "MINUS":
@@ -248,3 +248,10 @@ def type_check_gt(op: Op) -> None:
 def type_check_input() -> None:
     STACK.append(f"42") # User input length is not known beforehand
     STACK.append(f"*buf buffer")
+
+def type_check_le(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    check_popped_value_type(op, a, expected_type='INT')
+    check_popped_value_type(op, b, expected_type='INT')
+    STACK.append(a)
+    STACK.append(str(int(a<=b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -63,9 +63,9 @@ def type_check_program(program: Program) -> None:
         elif op.type == OpType.IF:
             return type_check_if(op)
         elif op.type == OpType.PUSH_ARRAY:
-            return type_check_push_array(op)
+            STACK.append(f"*buf s_arr{op.id}")
         elif op.type == OpType.PUSH_CSTR:
-            return type_check_push_cstr(op)
+            STACK.append(f"*buf cs{op.id}")
         elif op.type == OpType.PUSH_INT:
             STACK.append(op.token.value)
         elif op.type == OpType.PUSH_STR:
@@ -168,9 +168,3 @@ def type_check_dup(op: Op) -> str:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
     STACK.append(top)
     STACK.append(top)
-
-def type_check_push_array(op: Op) -> None:
-    STACK.append(f"*buf s_arr{op.id}")
-
-def type_check_push_cstr(op: Op) -> None:
-    STACK.append(f"*buf cs{op.id}")

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -57,11 +57,11 @@ def type_check_program(program: Program) -> None:
         if token.value.upper() in NOT_TYPED_TOKENS:
             continue
         elif op.type == OpType.DO:
-            return type_check_do(op)
+            type_check_do(op)
         elif op.type == OpType.ELIF:
-            return type_check_elif(op)
+            type_check_dup(op)  # ELIF duplicates the first element in the stack
         elif op.type == OpType.IF:
-            return type_check_if(op)
+            type_check_dup(op)  # IF duplicates the first element in the stack
         elif op.type == OpType.PUSH_ARRAY:
             STACK.append(f"*buf s_arr{op.id}")
         elif op.type == OpType.PUSH_CSTR:
@@ -69,9 +69,9 @@ def type_check_program(program: Program) -> None:
         elif op.type == OpType.PUSH_INT:
             STACK.append(op.token.value)
         elif op.type == OpType.PUSH_STR:
-            return type_check_push_str(op)
+            type_check_push_str(op)
         elif op.type == OpType.WHILE:
-            type_check_dup(op)
+            type_check_dup(op)  # WHILE duplicates the first element in the stack
         elif op.type == OpType.INTRINSIC:
             intrinsic: str = token.value.upper()
             if intrinsic == "AND":
@@ -153,13 +153,6 @@ def type_check_do(op: Op) -> None:
         STACK.pop()
     except IndexError:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
-
-# ELIF is like DUP, it duplicates the first element in the stack
-def type_check_elif(op: Op) -> None:
-    type_check_dup(op)
-
-def type_check_if(op: Op) -> None:
-    type_check_dup(op)
 
 def type_check_dup(op: Op) -> str:
     try:

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -103,7 +103,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "MINUS":
                 type_check_minus(op)
             elif intrinsic == "MOD":
-                continue #return type_check_mod(op)
+                type_check_mod(op)
             elif intrinsic == "MUL":
                 continue #return type_check_mul(op)
             elif intrinsic == "NE":
@@ -266,3 +266,7 @@ def type_check_lt(op: Op) -> None:
 def type_check_minus(op: Op) -> None:
     a, b = pop_two_from_stack(op)
     STACK.append(str(int(a) + int(b)))
+
+def type_check_mod(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    STACK.append(str(int(a) % int(b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -99,7 +99,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "LE":
                 type_check_le(op)
             elif intrinsic == "LT":
-                continue #return type_check_lt(op)
+                type_check_lt(op)
             elif intrinsic == "MINUS":
                 continue #return type_check_minus(op)
             elif intrinsic == "MOD":
@@ -255,3 +255,10 @@ def type_check_le(op: Op) -> None:
     check_popped_value_type(op, b, expected_type='INT')
     STACK.append(a)
     STACK.append(str(int(a<=b)))
+
+def type_check_lt(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    check_popped_value_type(op, a, expected_type='INT')
+    check_popped_value_type(op, b, expected_type='INT')
+    STACK.append(a)
+    STACK.append(str(int(a<b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -85,7 +85,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "DUP2":
                 type_check_dup2(op)
             elif intrinsic == "ENVP":
-                continue #return type_check_envp()
+                STACK.append('ENVP')
             elif intrinsic == "EQ":
                 continue #return type_check_eq(op)
             elif intrinsic == "GE":

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -147,7 +147,7 @@ def type_check_program(program: Program) -> None:
             compiler_error(op, "NOT_IMPLEMENTED", f"Type checking for {op.type.name} has not been implemented.")
     raise NotImplementedError("Type checking is not implemented yet.")
 
-def type_check_do(op: Op) -> str:
+def type_check_do(op: Op) -> None:
     try:
         STACK.pop()
         STACK.pop()

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -93,7 +93,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "GET_NTH":
                 type_check_nth(op)
             elif intrinsic == "GT":
-                continue #return type_check_gt(op)
+                type_check_gt(op)
             elif intrinsic == "INPUT":
                 continue #return type_check_input(op)
             elif intrinsic == "LE":
@@ -237,3 +237,10 @@ def type_check_nth(op: Op) -> None:
                     f"Cannot get {n+1}. element from the stack: Stack only contains {len(STACK)} elements.")
 
     STACK.append(nth_element)
+
+def type_check_gt(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    check_popped_value_type(op, a, expected_type='INT')
+    check_popped_value_type(op, b, expected_type='INT')
+    STACK.append(a)
+    STACK.append(str(int(a>b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -125,19 +125,19 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "SWAP2":
                 type_check_swap2(op)
             elif intrinsic == "SYSCALL0":
-                continue #return type_check_syscall(op, param_count=0)
+                type_check_syscall(op, param_count=0)
             elif intrinsic == "SYSCALL1":
-                continue #return type_check_syscall(op, param_count=1)
+                type_check_syscall(op, param_count=1)
             elif intrinsic == "SYSCALL2":
-                continue #return type_check_syscall(op, param_count=2)
+                type_check_syscall(op, param_count=2)
             elif intrinsic == "SYSCALL3":
-                continue #return type_check_syscall(op, param_count=3)
+                type_check_syscall(op, param_count=3)
             elif intrinsic == "SYSCALL4":
-                continue #return type_check_syscall(op, param_count=4)
+                type_check_syscall(op, param_count=4)
             elif intrinsic == "SYSCALL5":
-                continue #return type_check_syscall(op, param_count=5)
+                type_check_syscall(op, param_count=5)
             elif intrinsic == "SYSCALL6":
-                continue #return type_check_syscall(op, param_count=6)
+                type_check_syscall(op, param_count=6)
             else:
                 compiler_error(op, "NOT_IMPLEMENTED", f"Type checking for {intrinsic} has not been implemented.")
         else:
@@ -330,3 +330,15 @@ def type_check_swap2(op: Op) -> None:
     STACK.append(a)
     STACK.append(d)
     STACK.append(c)
+
+def type_check_syscall(op: Op, param_count: int) -> None:
+    try:
+        get_stack_after_syscall(STACK, param_count)
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
+
+def get_stack_after_syscall(stack: List[str], param_count: int) -> None:
+    _syscall = stack.pop()
+    for _i in range(param_count):
+        stack.pop()
+    stack.append('0') # Syscall return value is 0 if no errors occurred

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -65,7 +65,7 @@ def type_check_program(program: Program) -> None:
         elif op.type == OpType.PUSH_ARRAY:
             return type_check_push_array(op)
         elif op.type == OpType.PUSH_CSTR:
-            continue #return type_check_push_cstr(op)
+            return type_check_push_cstr(op)
         elif op.type == OpType.PUSH_INT:
             continue #return type_check_push_int(token)
         elif op.type == OpType.PUSH_STR:
@@ -171,3 +171,6 @@ def type_check_dup(op: Op) -> str:
 
 def type_check_push_array(op: Op) -> None:
     STACK.append(f"*buf s_arr{op.id}")
+
+def type_check_push_cstr(op: Op) -> None:
+    STACK.append(f"*buf cs{op.id}")

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -60,12 +60,6 @@ def type_check_program(program: Program) -> None:
             return type_check_do(op)
         elif op.type == OpType.ELIF:
             return type_check_elif(op)
-        elif op.type == OpType.ELSE:
-            continue #return type_check_else(op, program)
-        elif op.type == OpType.END:
-            continue #return type_check_end(op, program)
-        elif op.type == OpType.ENDIF:
-            continue #return type_check_endif(op)
         elif op.type == OpType.IF:
             return type_check_if(op)
         elif op.type == OpType.PUSH_ARRAY:
@@ -94,8 +88,6 @@ def type_check_program(program: Program) -> None:
                 continue #return type_check_dup2(op)
             elif intrinsic == "ENVP":
                 continue #return type_check_envp()
-            elif intrinsic == "EXIT":
-                continue #return type_check_exit()
             elif intrinsic == "EQ":
                 continue #return type_check_eq(op)
             elif intrinsic == "GE":
@@ -127,8 +119,6 @@ def type_check_program(program: Program) -> None:
             # TODO: Merge PRINT and PRINT_INT
             elif intrinsic == "PRINT":
                 continue #return type_check_string_output(op, intrinsic)
-            elif intrinsic == "PRINT_INT":
-                continue #return type_check_print_int()
             elif intrinsic == "PUTS":
                 continue #return type_check_string_output(op, intrinsic)
             elif intrinsic == "ROT":

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -69,7 +69,7 @@ def type_check_program(program: Program) -> None:
         elif op.type == OpType.PUSH_INT:
             STACK.append(op.token.value)
         elif op.type == OpType.PUSH_STR:
-            continue #return type_check_push_str(op)
+            return type_check_push_str(op)
         elif op.type == OpType.WHILE:
             continue #return type_check_while(op)
         elif op.type == OpType.INTRINSIC:
@@ -168,3 +168,9 @@ def type_check_dup(op: Op) -> str:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
     STACK.append(top)
     STACK.append(top)
+
+def type_check_push_str(op: Op) -> str:
+    str_val: str = op.token.value[1:-1]  # Take quotes out of the string
+    str_len: int = len(str_val) + 1      # Add newline
+    STACK.append(f"{str_len}")
+    STACK.append(f"*buf s{op.id}")

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -51,7 +51,7 @@ def run_code(exe_file: str) -> None:
 # Type check all operations which
 def type_check_program(program: Program) -> None:
     global STACK
-    NOT_TYPED_TOKENS: List[Token] = [ 'BREAK', 'ELSE', 'END', 'ENDIF', 'EXIT', 'PRINT_INT' ]
+    NOT_TYPED_TOKENS: List[Token] = [ 'BREAK', 'ELSE', 'END', 'ENDIF', 'EXIT' ]
     for op in program:
         token: Token = op.token
         if token.value.upper() in NOT_TYPED_TOKENS:
@@ -116,6 +116,8 @@ def type_check_program(program: Program) -> None:
                 type_check_pow(op)
             elif intrinsic in {"PRINT", "PUTS"}:
                 type_check_string_output(op, intrinsic)
+            elif intrinsic == "PRINT_INT":
+                type_check_print_int(op)
             elif intrinsic == "ROT":
                 type_check_rot(op)
             elif intrinsic == "SWAP":
@@ -314,6 +316,10 @@ def type_check_string_output(op: Op, intrinsic: str) -> None:
 
     check_popped_value_type(op, buf, expected_type='*buf')
     check_popped_value_type(op, count, expected_type='INT')
+
+def type_check_print_int(op: Op) -> None:
+    integer: str = STACK.pop()
+    check_popped_value_type(op, integer, expected_type='INT')
 
 def type_check_rot(op: Op) -> None:
     try:

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -81,9 +81,9 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "DROP":
                 type_check_drop(op)
             elif intrinsic == "DUP":
-                continue #return type_check_dup(op)
+                type_check_dup(op)
             elif intrinsic == "DUP2":
-                continue #return type_check_dup2(op)
+                type_check_dup2(op)
             elif intrinsic == "ENVP":
                 continue #return type_check_envp()
             elif intrinsic == "EQ":
@@ -200,3 +200,14 @@ def type_check_dup(op: Op) -> None:
         compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
     STACK.append(top)
     STACK.append(top)
+
+def type_check_dup2(op: Op) -> None:
+    try:
+        b = STACK.pop()
+        a = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Cannot duplicate value from empty stack.")
+    STACK.append(a)
+    STACK.append(b)
+    STACK.append(a)
+    STACK.append(b)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -87,7 +87,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "ENVP":
                 STACK.append('ENVP')
             elif intrinsic == "EQ":
-                continue #return type_check_eq(op)
+                type_check_eq(op)
             elif intrinsic == "GE":
                 continue #return type_check_ge(op)
             elif intrinsic == "GET_NTH":
@@ -211,3 +211,15 @@ def type_check_dup2(op: Op) -> None:
     STACK.append(b)
     STACK.append(a)
     STACK.append(b)
+
+def type_check_eq(op: Op) -> None:
+    try:
+        b = STACK.pop()
+        a = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
+
+    check_popped_value_type(op, a, expected_type='INT')
+    check_popped_value_type(op, b, expected_type='INT')
+    STACK.append(a)
+    STACK.append(str(int(a==b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -123,7 +123,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "SWAP":
                 type_check_swap(op)
             elif intrinsic == "SWAP2":
-                continue #return type_check_swap2(op)
+                type_check_swap2(op)
             elif intrinsic == "SYSCALL0":
                 continue #return type_check_syscall(op, param_count=0)
             elif intrinsic == "SYSCALL1":
@@ -317,3 +317,16 @@ def type_check_swap(op: Op) -> None:
     a, b = pop_two_from_stack(op)
     STACK.append(b)
     STACK.append(a)
+
+def type_check_swap2(op: Op) -> None:
+    try:
+        a = STACK.pop()
+        b = STACK.pop()
+        c = STACK.pop()
+        d = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "Not enough values in the stack.")
+    STACK.append(b)
+    STACK.append(a)
+    STACK.append(d)
+    STACK.append(c)

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -111,7 +111,7 @@ def type_check_program(program: Program) -> None:
             elif intrinsic == "OVER":
                 type_check_over(op)
             elif intrinsic == "PLUS":
-                continue #return type_check_plus(op)
+                type_check_plus(op)
             elif intrinsic == "POW":
                 continue #return type_check_pow(op)
             # TODO: Merge PRINT and PRINT_INT
@@ -287,3 +287,7 @@ def type_check_over(op: Op) -> None:
     STACK.append(a)
     STACK.append(b)
     STACK.append(a)
+
+def type_check_plus(op: Op) -> None:
+    a, b = pop_two_from_stack(op)
+    STACK.append(str(int(a) + int(b)))

--- a/compiler/program.py
+++ b/compiler/program.py
@@ -114,13 +114,12 @@ def type_check_program(program: Program) -> None:
                 type_check_plus(op)
             elif intrinsic == "POW":
                 continue #return type_check_pow(op)
-            # TODO: Merge PRINT and PRINT_INT
             elif intrinsic == "PRINT":
                 type_check_string_output(op, intrinsic)
             elif intrinsic == "PUTS":
                 type_check_string_output(op, intrinsic)
             elif intrinsic == "ROT":
-                continue #return type_check_rot(op)
+                type_check_rot(op)
             elif intrinsic == "SWAP":
                 continue #return type_check_swap(op)
             elif intrinsic == "SWAP2":
@@ -292,7 +291,7 @@ def type_check_plus(op: Op) -> None:
     a, b = pop_two_from_stack(op)
     STACK.append(str(int(a) + int(b)))
 
-def type_check_string_output(op: Op, intrinsic: str) -> str:
+def type_check_string_output(op: Op, intrinsic: str) -> None:
     try:
         buf    = STACK.pop()
         count  = STACK.pop()
@@ -302,3 +301,14 @@ def type_check_string_output(op: Op, intrinsic: str) -> str:
 
     check_popped_value_type(op, buf, expected_type='*buf')
     check_popped_value_type(op, count, expected_type='INT')
+
+def type_check_rot(op: Op) -> None:
+    try:
+        a = STACK.pop()
+        b = STACK.pop()
+        c = STACK.pop()
+    except IndexError:
+        compiler_error(op, "POP_FROM_EMPTY_STACK", "The stack does not contain three elements to rotate.")
+    STACK.append(a)
+    STACK.append(c)
+    STACK.append(b)

--- a/examples/execve.torth
+++ b/examples/execve.torth
@@ -1,6 +1,0 @@
-// This program runs Linux command 'wget example.com -O example.html' with execve syscall
-// which gets the contents of the example.com webpage and saves it to example.html file.
-
-// The execve command is constructed with the following strace output:
-// execve("/usr/bin/wget", ["wget", "example.com", "-O", "example.html"], 0x7ffffec61f68)
-envp array("wget","example.com","-O","example.html") '/usr/bin/wget' 59 syscall3

--- a/examples/fibonacci.torth
+++ b/examples/fibonacci.torth
@@ -9,7 +9,7 @@ WHILE 20 >= DO
   // Add the two numbers in the top of the stack together (Previous and Current)
   +
   // Print the sum
-  print_int
+  dup print_int
   // Rotate stack to the original position (Previous, Current, counter)
   rot rot
   // Increment counter for WHILE loop

--- a/examples/fizzbuzz.torth
+++ b/examples/fizzbuzz.torth
@@ -1,11 +1,11 @@
 0 // The sum of numbers not divisible by 3 or 5
 1 WHILE 30 >= DO
     IF 15 % 0 == DO
-        "FizzBuzz  " print print_int
+        "FizzBuzz  " print dup print_int
     ELIF 3 % 0 == DO
-        "Fizz      " print print_int
+        "Fizz      " print dup print_int
     ELIF 5 % 0 == DO
-        "Buzz      " print print_int
+        "Buzz      " print dup print_int
     ELSE
         // Add current number to the sum of numbers not divisible by 3 or 5
         dup rot + swap

--- a/examples/loops.torth
+++ b/examples/loops.torth
@@ -1,6 +1,6 @@
-"WHILE loop" puts   // puts("WHILE loop");
-1                   // i = 1;
-WHILE 10 >= DO      // while (10 >= i) {
-    "Row " PRINT .  //   printf("Row %d\n", i);
-    1 +             //   i++;
-END                 // }
+"WHILE loop" puts       // puts("WHILE loop");
+1                       // i = 1;
+WHILE 10 >= DO          // while (10 >= i) {
+    "Row " PRINT dup .  //   printf("Row %d\n", i);
+    1 +                 //   i++;
+END                     // }


### PR DESCRIPTION
Refactored type checking with virtual stack away from compiler.asm module to a separate type_check_program function in compiler.program module.

Other changes:
- PRINT_INT now also pops the value out of the stack
- ENVP intrinsic was removed due it not working after changing the linker from GCC to LD